### PR TITLE
ensure lint params are confirmed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,16 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
-    - pbr
+    - python
+    - pbr ==5.6.0
     - pip
+    - wheel
   run:
-    - python >=3.6
+    - python
     - attrs
     - jsonpickle
     - pbr
@@ -36,9 +37,13 @@ test:
 
 about:
   home: https://github.com/microsoft/jschema-to-python
+  dev_url: https://github.com/microsoft/jschema-to-python
+  doc_url: https://github.com/microsoft/jschema-to-python
   summary: Generate source code for Python classes from a JSON schema.
+  description: Generate source code for Python classes from a JSON schema.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ about:
   home: https://github.com/microsoft/jschema-to-python
   dev_url: https://github.com/microsoft/jschema-to-python
   doc_url: https://github.com/microsoft/jschema-to-python
-  summary: Generate source code for Python classes from a JSON schema.
-  description: Generate source code for Python classes from a JSON schema.
+  summary: Generate source code for Python classes from JSON schema.
+  description: Generate source code for Python classes from JSON schema.
   license: MIT
   license_file: LICENSE
   license_family: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ build:
 requirements:
   host:
     - python
-    - pbr ==5.6.0
+    - pbr
     - pip
     - wheel
+    - setuptools
   run:
     - python
     - attrs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -39,8 +38,8 @@ about:
   home: https://github.com/microsoft/jschema-to-python
   dev_url: https://github.com/microsoft/jschema-to-python
   doc_url: https://github.com/microsoft/jschema-to-python
-  summary: Generate source code for Python classes from JSON schema.
-  description: Generate source code for Python classes from JSON schema.
+  summary: Generate source code for Python classes from a JSON schema.
+  description: Generate source code for Python classes from a JSON schema.
   license: MIT
   license_file: LICENSE
   license_family: MIT


### PR DESCRIPTION
jschema-to-python 1.2.3

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/microsoft/jschema-to-python)

### Explanation of changes:

- Adjust for lint ready to upload to defaults
